### PR TITLE
Fixed EXC_BAD_ACCESS on launch

### DIFF
--- a/BLWebSocketsServer/BLWebSocketsServer.m
+++ b/BLWebSocketsServer/BLWebSocketsServer.m
@@ -34,8 +34,8 @@ static BLWebSocketsServer *sharedInstance = nil;
 @interface BLWebSocketsServer()
 
 @property (nonatomic, assign, readwrite) BOOL isRunning;
-@property (nonatomic, assign) dispatch_source_t timer;
-@property (nonatomic, assign) dispatch_queue_t networkQueue;
+@property (nonatomic, retain) dispatch_source_t timer;
+@property (nonatomic, retain) dispatch_queue_t networkQueue;
 /* Context representing the server */
 @property (nonatomic, assign) struct libwebsocket_context *context;
 @property (nonatomic, strong) BLAsyncMessageQueue *asyncMessageQueue;
@@ -164,7 +164,7 @@ static BLWebSocketsServer *sharedInstance = nil;
 }
 
 - (void)cleanup {
-    dispatch_release(self.timer);
+//    dispatch_release(self.timer);
     [self destroyContext:self.context];
     self.context = NULL;
     [self.asyncMessageQueue reset];


### PR DESCRIPTION
Both `timer` and `networkQueue` were not being retained, which lead to an `EXC_BAD_ACCESS` crash on iOS 7 and iOS 8 as they were immediately released after being assigned.
