### PR TITLE
Fixed project setup problems & ARC problems

### DIFF
--- a/BLWebSocketsServer.xcodeproj/project.pbxproj
+++ b/BLWebSocketsServer.xcodeproj/project.pbxproj
@@ -286,7 +286,7 @@
 			name = BLWebSocketsServerTests;
 			productName = BLWebSocketsServerTests;
 			productReference = B57C323016AF3A46004A6B5F /* BLWebSocketsServerTests.octest */;
-			productType = "com.apple.product-type.bundle";
+			productType = "com.apple.product-type.bundle.ocunit-test";
 		};
 /* End PBXNativeTarget section */
 
@@ -462,7 +462,7 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -484,7 +484,7 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -523,7 +523,7 @@
 					"\"$(DEVELOPER_LIBRARY_DIR)/Frameworks\"",
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "BLWebSocketsServer/BLWebSocketsServer-Prefix.pch";
+				GCC_PREFIX_HEADER = "Example/BLWebSocketsServer-Prefix.pch";
 				INFOPLIST_FILE = "BLWebSocketsServerTests/BLWebSocketsServerTests-Info.plist";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUNDLE_LOADER)";
@@ -540,7 +540,7 @@
 					"\"$(DEVELOPER_LIBRARY_DIR)/Frameworks\"",
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "BLWebSocketsServer/BLWebSocketsServer-Prefix.pch";
+				GCC_PREFIX_HEADER = "Example/BLWebSocketsServer-Prefix.pch";
 				INFOPLIST_FILE = "BLWebSocketsServerTests/BLWebSocketsServerTests-Info.plist";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUNDLE_LOADER)";

--- a/BLWebSocketsServer/BLWebSocketsServer.m
+++ b/BLWebSocketsServer/BLWebSocketsServer.m
@@ -164,7 +164,7 @@ static BLWebSocketsServer *sharedInstance = nil;
 }
 
 - (void)cleanup {
-    dispatch_release(self.timer);
+//    dispatch_release(self.timer);
     [self destroyContext:self.context];
     self.context = NULL;
     [self.asyncMessageQueue reset];


### PR DESCRIPTION
The project did not compile successfully on iOS 7 and iOS 8, which is fixed in this request. This includes removing `dispatch_release`, setting the deployment target to iOS 6 and some minor project setup issues.

IMPORTANT: I didn't test this with iOS 6 - if we want to keep iOS 5/6 compatibility this should NOT be merged. Technically, I don't see an issue why this code shouldn't work on earlier iOS versions (ARC is supported since iOS 4 if I'm not mistaken?), but its untested.
