### PR TITLE
Changed polling behaviour to speed up response time

### DIFF
--- a/BLWebSocketsServer/BLWebSocketsServer.m
+++ b/BLWebSocketsServer/BLWebSocketsServer.m
@@ -11,7 +11,7 @@
 #import "private-libwebsockets.h"
 #import "BLAsyncMessageQueue.h"
 
-static int pollingInterval = 20000;
+static int pollingInterval = INT_MAX;
 static NSString * http_only_protocol = @"http-only";
 const char * queueIdentifier = "com.blwebsocketsserver.network";
 /* Error constants */
@@ -127,11 +127,11 @@ static BLWebSocketsServer *sharedInstance = nil;
     
     self.timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, self.networkQueue);
     
-    dispatch_source_set_timer(self.timer,DISPATCH_TIME_NOW, pollingInterval*NSEC_PER_USEC, (pollingInterval/2)*NSEC_PER_USEC);
+    dispatch_source_set_timer(self.timer, DISPATCH_TIME_NOW, 1, 1);
     
     dispatch_source_set_event_handler(self.timer, ^{
         @autoreleasepool {
-            libwebsocket_service(self.context, 0);
+            libwebsocket_service(self.context, pollingInterval);
         }
     });
     


### PR DESCRIPTION
This commit changes the polling behaviour to exploit the blocking behaviour of `libwebsocket_service()`.
This means:
1. The dispatch timer is now fired immediately
2. `libwebsocket_service()` is called with a very long timeout, which will block until the callback is called. After the callback has been executed, the dispatch timer will fire immediately again

In some small tests, I could see a large improvement of round-trip-time, in particular when lots of small messages are received in rapid succession (up to 50% less RTT). There seems to be no increase in CPU usage. The only downside I can think of is that the networkQueue is blocked, which shouldn't matter as its only purpose is to wait for an event and execute the callback.

Note that such an approach is also mentioned in the API description of `libwebsocket_service`:

"Alternatively you can fork a new process that asynchronously handles calling this service in a loop. In that case you are happy if this call blocks your thread until it needs to take care of something and would call it with a large nonzero timeout. Your loop then takes no CPU while there is nothing happening." (https://libwebsockets.org/libwebsockets-api-doc.html)
